### PR TITLE
Update repo to active kubernetes version on AKS

### DIFF
--- a/.github/workflows/stamp-install.yaml
+++ b/.github/workflows/stamp-install.yaml
@@ -46,7 +46,7 @@ jobs:
         run: export FLUX_VERSION=0.27.4 && curl -s https://fluxcd.io/install.sh | bash;
 
       - name: Bootstrap Flux
-        run: flux bootstrap github --owner=${{ github.repository_owner }} --repository=$(echo $GITHUB_REPOSITORY | cut -d'/' -f2	) --branch=main --path=./clusters/${{ env.CLUSTER }}
+        run: flux bootstrap github --owner=${{ github.repository_owner }} --repository=$(echo $GITHUB_REPOSITORY | cut -d'/' -f2	) --branch=${{ github.ref_name }} --path=./clusters/${{ env.CLUSTER }}
 
       - name: GitOps Checkout
         uses: actions/checkout@v2

--- a/configuration/dataplane.tfvars
+++ b/configuration/dataplane.tfvars
@@ -29,7 +29,7 @@ subnet_aks_prefix = "10.10.2.0/23"
 subnet_be_prefix  = "10.10.3.0/28"
 
 # Kubernetes Settings
-kubernetes_version = "1.20.9"
+kubernetes_version = "1.21.9"
 aks_agent_vm_count = "6"
 aks_agent_vm_disk  = 128
 aks_agent_vm_size  = "Standard_E4s_v3"

--- a/customizations/templates/service_resources/main.tf
+++ b/customizations/templates/service_resources/main.tf
@@ -378,6 +378,7 @@ module "aks" {
   dns_prefix                 = local.aks_dns_prefix
   network_plugin             = "azure"
   #identity_type          = "UserAssigned"
+  kubernetes_version          = var.kubernetes_version
   network_policy         = "azure"
   configure_network_role = true
 

--- a/customizations/templates/service_resources/terraform.tfvars
+++ b/customizations/templates/service_resources/terraform.tfvars
@@ -39,7 +39,7 @@ resource_tags = {
 }
 
 # Kubernetes Settings
-kubernetes_version = "1.20.9"
+kubernetes_version = "1.21.9"
 aks_agent_vm_size  = "Standard_E4s_v3"
 aks_agent_vm_count = "5"
 aks_agent_vm_disk  = 128

--- a/customizations/templates/service_resources/variables.tf
+++ b/customizations/templates/service_resources/variables.tf
@@ -267,7 +267,7 @@ variable "aks_agent_vm_disk" {
 
 variable "kubernetes_version" {
   type    = string
-  default = "1.19.11"
+  default = "1.21.9"
 }
 
 variable "ssh_public_key_file" {


### PR DESCRIPTION
Upgrade AKS kubernetes version to 1.21.9 and add variable for flux bootstrap command to use the relative repo the github action is run from.